### PR TITLE
別のユーザーが同じ作者をお気に入り登録したときに生じるエラーを解消

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -30,7 +30,7 @@ class AuthorsController < ApplicationController
         size: b.size
       )
     end
-    FavoredAuthorBook.import favored_author_books
+    FavoredAuthorBook.import favored_author_books, on_duplicate_key_update: {conflict_target: [:isbn]}
 
     # noticesテーブルにcurrent_user.idとfavored_author_book_idを登録
     favored_author_books.each do |b|


### PR DESCRIPTION
## 内容
favored_author_booksのimport時にisbnのconflictを許可する