### PR TITLE
favored_booksテーブル・FavoredBookモデルを作成

### DIFF
--- a/app/models/book_favorite.rb
+++ b/app/models/book_favorite.rb
@@ -1,0 +1,8 @@
+class BookFavorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :favored_book
+  validates :user_id, uniqueness: {
+    scope: :favored_book_id,
+    message: "は同じ系列の本に2回以上いいねはできません"
+  }
+end

--- a/app/models/favored_book.rb
+++ b/app/models/favored_book.rb
@@ -1,0 +1,2 @@
+class FavoredBook < ApplicationRecord
+end

--- a/app/models/favored_book.rb
+++ b/app/models/favored_book.rb
@@ -1,2 +1,5 @@
 class FavoredBook < ApplicationRecord
+  has_many :book_favorites, dependent: :destroy
+  has_many :favorite_books, through: :book_favorites, source: :user
+  validates :title_kana, presence: true, uniqueness: {message: "はすでにお気に入り登録されています"}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,10 @@ class User < ApplicationRecord
 
   has_many :author_favorites, dependent: :destroy
   has_many :favored_authors, through: :author_favorites, source: :author
+  has_many :book_favorites, dependent: :destroy
+  has_many :favorite_books, through: :book_favorites, source: :favored_books
   has_many :notices, dependent: :destroy
   has_many :notice_books, through: :notices, source: :favored_author_book
-
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and 

--- a/db/migrate/20201215110424_create_favored_books.rb
+++ b/db/migrate/20201215110424_create_favored_books.rb
@@ -1,6 +1,16 @@
 class CreateFavoredBooks < ActiveRecord::Migration[6.0]
   def change
     create_table :favored_books do |t|
+      t.string :author_name
+      t.string :isbn
+      t.string :title
+      t.string :title_kana
+      t.string :sales_date
+      t.integer :days_to_release
+      t.string :item_url
+      t.string :item_price
+      t.string :publisher_name
+      t.string :size
 
       t.timestamps
     end

--- a/db/migrate/20201215110424_create_favored_books.rb
+++ b/db/migrate/20201215110424_create_favored_books.rb
@@ -1,0 +1,8 @@
+class CreateFavoredBooks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :favored_books do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201215110934_create_book_favorites.rb
+++ b/db/migrate/20201215110934_create_book_favorites.rb
@@ -1,0 +1,11 @@
+class CreateBookFavorites < ActiveRecord::Migration[6.0]
+  def change
+    create_table :book_favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :favored_book, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index: book_favorites, [:user_id, :favored_book_id], unique: true
+  end
+end

--- a/spec/factories/book_favorites.rb
+++ b/spec/factories/book_favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :book_favorite do
+    user { nil }
+    favored_book { nil }
+  end
+end

--- a/spec/factories/favored_books.rb
+++ b/spec/factories/favored_books.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :favored_book do
+    
+  end
+end

--- a/spec/models/book_favorite_spec.rb
+++ b/spec/models/book_favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BookFavorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favored_book_spec.rb
+++ b/spec/models/favored_book_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FavoredBook, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 説明
- favored_booksテーブルはtitle_kanaで一意性制約される。
- 同じtitle_kanaを持つ本が発売されるとき、ユーザーにその本の内容を通知するためのテーブル。
- 例えばワンピースだと　ワンピース 96巻とワンピース97巻は同じ"ワンピース"というtitle_kanaで表されるため、favored_booksに登録することはシリーズを登録することになる