### PR TITLE
BookNoticeモデル・book_noticesテーブルの作成

### DIFF
--- a/app/models/book_notice.rb
+++ b/app/models/book_notice.rb
@@ -1,0 +1,4 @@
+class BookNotice < ApplicationRecord
+  belongs_to :user
+  belongs_to :favored_book
+end

--- a/app/models/book_notice.rb
+++ b/app/models/book_notice.rb
@@ -1,4 +1,10 @@
+# 発売日が近いfavored_booksのデータをユーザーに通知するためのテーブル
+
 class BookNotice < ApplicationRecord
   belongs_to :user
   belongs_to :favored_book
+  validates :user_id, uniqueness: {
+    scope: :favored_book_id,
+    message: "は同じ系列の本を2回以上登録できません"
+  }
 end

--- a/app/models/favored_book.rb
+++ b/app/models/favored_book.rb
@@ -6,4 +6,6 @@ class FavoredBook < ApplicationRecord
   has_many :book_favorites, dependent: :destroy
   has_many :favorite_books, through: :book_favorites, source: :user
   validates :title_kana, presence: true, uniqueness: {message: "はすでにお気に入り登録されています"}
+  has_many :book_notices, dependent: :destroy
+  has_many :notice_favored_books, through: :book_notices, source: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :favorite_books, through: :book_favorites, source: :favored_books
   has_many :notices, dependent: :destroy
   has_many :notice_books, through: :notices, source: :favored_author_book
+  has_many :book_notices, dependent: :destroy
+  has_many :notice_favored_books, through: :book_notices, source: :favored_book
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and 

--- a/db/migrate/20201215114524_create_book_notices.rb
+++ b/db/migrate/20201215114524_create_book_notices.rb
@@ -1,0 +1,10 @@
+class CreateBookNotices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :book_notices do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :favored_book, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201215114524_create_book_notices.rb
+++ b/db/migrate/20201215114524_create_book_notices.rb
@@ -6,5 +6,6 @@ class CreateBookNotices < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+    add_index :book_notices, [:user_id, :favored_book_id], unique: true
   end
 end

--- a/db/migrate/20201215114524_create_book_notices.rb
+++ b/db/migrate/20201215114524_create_book_notices.rb
@@ -3,6 +3,7 @@ class CreateBookNotices < ActiveRecord::Migration[6.0]
     create_table :book_notices do |t|
       t.references :user, null: false, foreign_key: true
       t.references :favored_book, null: false, foreign_key: true
+      t.integer :notice_flag, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_15_111000) do
+ActiveRecord::Schema.define(version: 2020_12_15_114524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,16 @@ ActiveRecord::Schema.define(version: 2020_12_15_111000) do
     t.index ["favored_book_id"], name: "index_book_favorites_on_favored_book_id"
     t.index ["user_id", "favored_book_id"], name: "index_book_favorites_on_user_id_and_favored_book_id", unique: true
     t.index ["user_id"], name: "index_book_favorites_on_user_id"
+  end
+
+  create_table "book_notices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "favored_book_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["favored_book_id"], name: "index_book_notices_on_favored_book_id"
+    t.index ["user_id", "favored_book_id"], name: "index_book_notices_on_user_id_and_favored_book_id", unique: true
+    t.index ["user_id"], name: "index_book_notices_on_user_id"
   end
 
   create_table "books", force: :cascade do |t|
@@ -111,6 +121,8 @@ ActiveRecord::Schema.define(version: 2020_12_15_111000) do
   add_foreign_key "author_favorites", "users"
   add_foreign_key "book_favorites", "favored_books"
   add_foreign_key "book_favorites", "users"
+  add_foreign_key "book_notices", "favored_books"
+  add_foreign_key "book_notices", "users"
   add_foreign_key "notices", "favored_author_books"
   add_foreign_key "notices", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_12_15_114524) do
   create_table "book_notices", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "favored_book_id", null: false
+    t.integer "notice_flag", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["favored_book_id"], name: "index_book_notices_on_favored_book_id"

--- a/spec/factories/book_notices.rb
+++ b/spec/factories/book_notices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :book_notice do
+    user { nil }
+    favored_book { nil }
+  end
+end

--- a/spec/models/book_notice_spec.rb
+++ b/spec/models/book_notice_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BookNotice, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 説明
- book_noticesテーブルは発売日の近いfavored_booksのデータをユーザーに通知する際に使用する。
- usersとfavored_booksの中間テーブル