### PR TITLE
Feature/add author column to title kanas table

### DIFF
--- a/app/controllers/title_kanas_controller.rb
+++ b/app/controllers/title_kanas_controller.rb
@@ -44,6 +44,6 @@ class TitleKanasController < ApplicationController
   private
 
   def title_kana_params
-    params.require(:title_kana).permit(:title_kana)
+    params.require(:title_kana).permit(:title_kana, :author)
   end
 end

--- a/app/controllers/title_kanas_controller.rb
+++ b/app/controllers/title_kanas_controller.rb
@@ -44,6 +44,6 @@ class TitleKanasController < ApplicationController
   private
 
   def title_kana_params
-    params.require(:title_kana).permit(:title_kana, :author)
+    params.require(:title_kana).permit(:title_kana, :author_name)
   end
 end

--- a/app/controllers/title_kanas_controller.rb
+++ b/app/controllers/title_kanas_controller.rb
@@ -21,7 +21,7 @@ class TitleKanasController < ApplicationController
         author_name: b.author,
         isbn: b.isbn,
         title: b.title,
-        title_kana: title_kana.title_kana,
+        title_kana: b.title_kana,
         sales_date: b.sales_date,
         days_to_release: rational_type_days_to_release.to_i,
         publisher_name: b.publisher_name,
@@ -30,6 +30,7 @@ class TitleKanasController < ApplicationController
         size: b.size
       )
     end
+    binding.pry
     FavoredBook.import favored_books, on_duplicate_key_update: {conflict_target: [:isbn]}
 
     # book_noticesテーブルにcurrent_user.idとfavored_book_idを登録

--- a/app/controllers/title_kanas_controller.rb
+++ b/app/controllers/title_kanas_controller.rb
@@ -9,6 +9,7 @@ class TitleKanasController < ApplicationController
     #お気に入り登録した作品カナの本を取得
     to_be_favored_books = RakutenWebService::Books::Book.search(
       title_kana: title_kana.title_kana,
+      author: title_kana.author_name,
       booksGenreId: "001",
       orFlag: 0,
       sort: "-releaseDate"
@@ -30,12 +31,12 @@ class TitleKanasController < ApplicationController
         size: b.size
       )
     end
-    binding.pry
+    
     FavoredBook.import favored_books, on_duplicate_key_update: {conflict_target: [:isbn]}
 
     # book_noticesテーブルにcurrent_user.idとfavored_book_idを登録
     favored_books.each do |b|
-      current_user.notices.create!(favored_book_id: b.id)
+      current_user.book_notices.create!(favored_book_id: b.id)
     end
 
     redirect_back(fallback_location: root_path)

--- a/app/views/title_kanas/_not_favorite.html.erb
+++ b/app/views/title_kanas/_not_favorite.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: title_kana, url: {controller: "title_kanas", action: "create"}, method: :post, local: true do |f| %>
   <%= f.hidden_field :title_kana, value: book.title_kana %>
-  <%= f.hidden_field :author, value: book.author %>
+  <%= f.hidden_field :author_name, value: book.author %>
   <%= f.submit "☆" %>
 <% end %>

--- a/app/views/title_kanas/_not_favorite.html.erb
+++ b/app/views/title_kanas/_not_favorite.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: title_kana, url: {controller: "title_kanas", action: "create"}, method: :post, local: true do |f| %>
   <%= f.hidden_field :title_kana, value: book.title_kana %>
-  <%= f.hidden_field :author_name, value: book.author %>
+  <%= f.hidden_field :author_name, value: book.author.delete("/ |　/") %>
   <%= f.submit "☆" %>
 <% end %>

--- a/app/views/title_kanas/_not_favorite.html.erb
+++ b/app/views/title_kanas/_not_favorite.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: title_kana, url: {controller: "title_kanas", action: "create"}, method: :post, local: true do |f| %>
   <%= f.hidden_field :title_kana, value: book.title_kana %>
+  <%= f.hidden_field :author, value: book.author %>
   <%= f.submit "☆" %>
 <% end %>

--- a/db/migrate/20201215110620_create_title_kanas.rb
+++ b/db/migrate/20201215110620_create_title_kanas.rb
@@ -2,6 +2,7 @@ class CreateTitleKanas < ActiveRecord::Migration[6.0]
   def change
     create_table :title_kanas do |t|
       t.string :title_kana, null: false
+      t.string :author_name, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2020_12_15_114524) do
 
   create_table "title_kanas", force: :cascade do |t|
     t.string "title_kana", null: false
+    t.string "author_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
## 説明
favored_booksテーブルにtitle_kanasテーブルに登録した本を登録する際、
```
 to_be_favored_books = RakutenWebService::Books::Book.search(
      title_kana: title_kana.title_kana,
      booksGenreId: "001",
      orFlag: 0,
      sort: "-releaseDate"
```

とするとfavored_booksテーブルに、作品カナにtitle_kanaを含む別の作者の本が大量に登録されるため、
```
to_be_favored_books = RakutenWebService::Books::Book.search(
      title_kana: title_kana.title_kana,
      author: title_kana.author_name,
      booksGenreId: "001",
      orFlag: 0,
      sort: "-releaseDate"
```
とすることで、登録したい作者の本だけに絞れるようにした