### PR TITLE
topページのお気に入り登録/解除ボタンのレイアウト設定

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -13,7 +13,6 @@
   color: #2cbae7;
   background-color: rgba(255, 255, 255, 0.5);
   padding: 1rem 10px;
-  display: inline-block;
   font-size: 2rem;
   font-weight:bold;
 }
@@ -31,15 +30,18 @@
 }
 
 .favorite_button_container{
-  display: flex;
   margin-bottom:10px;
 }
 
 .favorite_button{
   border: none;
-  outline: none;
-  background-color:transparent;
-  background: transparent;
+  background: #2cbae7;
+  color: white;
+  white-space: pre-line;
+  word-break: break-word;
+  border-radius:0.5rem;
+  // line-height:1.25rem;
+  margin:0.25rem 0 1rem 0;
 }
 
 .favorite_button_item{

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -33,6 +33,14 @@
   margin-bottom:10px;
 }
 
+.favorite_button_item{
+  margin: 0.25rem 0 0 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+
 .favorite_button{
   border: none;
   background: #2cbae7;
@@ -42,8 +50,4 @@
   border-radius:0.5rem;
   // line-height:1.25rem;
   margin:0.25rem 0 1rem 0;
-}
-
-.favorite_button_item{
-  margin: 0.25rem 0 0 8px;
 }

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -51,3 +51,14 @@
   // line-height:1.25rem;
   margin:0.25rem 0 1rem 0;
 }
+
+.remove_from_favorite_button{
+  border: none;
+  background: #c3597d;
+  color: white;
+  white-space: pre-line;
+  word-break: break-word;
+  border-radius:0.5rem;
+  // line-height:1.25rem;
+  margin:0.25rem 0 1rem 0;
+}

--- a/app/views/books/_book_list.html.erb
+++ b/app/views/books/_book_list.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="card-body book-body bg-primary p-2" style= "height: 310px; color:#626262;">
       <div class = "favorite_button_container" >
-        <div class = "favorite_button">
+        <p class = "favorite_button_item"><%= book.title %></p>
           <% if user_signed_in? %>
             <% title_kana = TitleKana.registered(book) %>
             <% if BookFavorite.favored_by?(title_kana, current_user) %>
@@ -16,12 +16,10 @@
           <% else %>
             <%= render "title_kanas/not_favorite", title_kana: title_kana, book: book %>
           <% end %>
-        </div>
-          <p class = "favorite_button_item"><%= book.title %></p>
       </div>
       
       <div class = "favorite_button_container" >
-        <div class = "favorite_button">
+        <p class = "favorite_button_item"><%= book.author %></p>
           <% if user_signed_in? %>
             <% author = Author.registered(book) %>
             <% if AuthorFavorite.favored_by?(author, current_user) %>
@@ -32,8 +30,6 @@
           <% else %>
             <%= render "not_favorite", {author: author, book: book} %>
           <% end %>
-        </div>
-        <p class = "favorite_button_item"><%= book.author %></p>
       </div>
 
       <p><%= book.sales_date %>発売</p>

--- a/app/views/books/_favorite.html.erb
+++ b/app/views/books/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= form_with url: author_author_favorites_path(author_id: author.id), method: :delete, local: true do |f| %>
-  <%= f.submit "★" %>
+  <%= f.submit "この作者の新刊情報を受け取らない" %>
 <% end %>

--- a/app/views/books/_favorite.html.erb
+++ b/app/views/books/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= form_with url: author_author_favorites_path(author_id: author.id), method: :delete, local: true do |f| %>
-  <%= f.submit "この作者の新刊情報を受け取らない" %>
+  <%= f.submit "この作者の新刊情報を受け取らない", class: "remove_from_favorite_button" %>
 <% end %>

--- a/app/views/books/_not_favorite.html.erb
+++ b/app/views/books/_not_favorite.html.erb
@@ -1,10 +1,10 @@
 <% if user_signed_in? %>
   <%= form_with model: author, url: {controller: "authors", action: "create"}, method: :post, local: true do |f| %>
     <%= f.hidden_field :author_name, value: book.author.delete("/ |　/") %>
-    <%= f.submit "☆" %>
+    <%= f.submit "この作者の新刊情報がほしい" %>
   <% end %>
 <% else %>
   <%= form_with url: new_user_session_path, local: true do |f| %>
-    <%= f.submit "☆" %>
+    <%= f.submit "この作者の新刊情報がほしい" %>
   <% end %>
 <% end %>

--- a/app/views/books/_not_favorite.html.erb
+++ b/app/views/books/_not_favorite.html.erb
@@ -1,10 +1,10 @@
 <% if user_signed_in? %>
   <%= form_with model: author, url: {controller: "authors", action: "create"}, method: :post, local: true do |f| %>
     <%= f.hidden_field :author_name, value: book.author.delete("/ |　/") %>
-    <%= f.submit "この作者の新刊情報がほしい" %>
+    <%= f.submit "この作者の新刊情報を通知",class: "favorite_button" %>
   <% end %>
 <% else %>
   <%= form_with url: new_user_session_path, local: true do |f| %>
-    <%= f.submit "この作者の新刊情報がほしい" %>
+    <%= f.submit "この作者の新刊情報を通知",class: "favorite_button" %>
   <% end %>
 <% end %>

--- a/app/views/title_kanas/_favorite.html.erb
+++ b/app/views/title_kanas/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= form_with url: title_kana_book_favorites_path(title_kana_id: title_kana.id), method: :delete, local: true do |f| %>
-  <%= f.submit "★" %>
+  <%= f.submit "このシリーズの新刊情報を受け取らない" %>
 <% end %>

--- a/app/views/title_kanas/_favorite.html.erb
+++ b/app/views/title_kanas/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= form_with url: title_kana_book_favorites_path(title_kana_id: title_kana.id), method: :delete, local: true do |f| %>
-  <%= f.submit "このシリーズの新刊情報を受け取らない" %>
+  <%= f.submit "このシリーズの新刊情報を受け取らない", class: "remove_from_favorite_button" %>
 <% end %>

--- a/app/views/title_kanas/_not_favorite.html.erb
+++ b/app/views/title_kanas/_not_favorite.html.erb
@@ -2,10 +2,10 @@
   <%= form_with model: title_kana, url: {controller: "title_kanas", action: "create"}, method: :post, local: true do |f| %>
     <%= f.hidden_field :title_kana, value: book.title_kana %>
     <%= f.hidden_field :author_name, value: book.author.delete("/ |　/") %>
-    <%= f.submit "このシリーズの新刊情報がほしい" %>
+    <%= f.submit "このシリーズの新刊情報を通知",class: "favorite_button" %>
   <% end %>
 <% else %>
   <%= form_with url: new_user_session_path, local: true do |f| %>
-    <%= f.submit "このシリーズの新刊情報がほしい" %>
+    <%= f.submit "このシリーズの新刊情報を通知", class: "favorite_button" %>
   <% end %>
 <% end %>

--- a/app/views/title_kanas/_not_favorite.html.erb
+++ b/app/views/title_kanas/_not_favorite.html.erb
@@ -2,10 +2,10 @@
   <%= form_with model: title_kana, url: {controller: "title_kanas", action: "create"}, method: :post, local: true do |f| %>
     <%= f.hidden_field :title_kana, value: book.title_kana %>
     <%= f.hidden_field :author_name, value: book.author.delete("/ |　/") %>
-    <%= f.submit "☆" %>
+    <%= f.submit "このシリーズの新刊情報がほしい" %>
   <% end %>
 <% else %>
   <%= form_with url: new_user_session_path, local: true do |f| %>
-    <%= f.submit "☆" %>
+    <%= f.submit "このシリーズの新刊情報がほしい" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 内容
- お気に入り登録ボタンは「このシリーズの新刊情報を通知」に設定
- お気に入り解除ボタンは「このシリーズの新刊情報を受け取らない」設定
- topページのお気に入り登録/解除ボタンのレイアウト設定
- 作品・作者名が一行に収まらないときは三点リーダーで表示