### PR TITLE
Feature/add image url to mail contents

### DIFF
--- a/app/mailers/favored_book_notification_mailer.rb
+++ b/app/mailers/favored_book_notification_mailer.rb
@@ -11,6 +11,7 @@ class FavoredBookNotificationMailer < ApplicationMailer
       @days_to_release = book.days_to_release
       @publisher_name = book.publisher_name
       @item_url = book.item_url
+      @large_image_url = book.large_image_url
       @item_price = book.item_price
       @size = book.size
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,6 +12,7 @@ class NotificationMailer < ApplicationMailer
       @days_to_release = book.days_to_release
       @publisher_name = book.publisher_name
       @item_url = book.item_url
+      @large_image_url = book.large_image_url
       @item_price = book.item_price
       @size = book.size
 

--- a/app/views/favored_book_notification_mailer/send_favored_book_notification_email.html.erb
+++ b/app/views/favored_book_notification_mailer/send_favored_book_notification_email.html.erb
@@ -3,6 +3,10 @@
   ぜひお買い逃しのないように！
 </p>
 
+<p>
+  <%= link_to_if(@large_image_url.present?, image_tag(@large_image_url), @item_url) %>
+</p>
+
   <table>
     <tr>
       <th align="left">発売日</th>

--- a/app/views/notification_mailer/send_notification_email.html.erb
+++ b/app/views/notification_mailer/send_notification_email.html.erb
@@ -3,6 +3,10 @@
   ぜひお買い逃しのないように！
 </p>
 
+<p>
+  <%= link_to_if(@large_image_url.present?, image_tag(@large_image_url), @item_url) %>
+</p>
+
   <table>
     <tr>
       <th align="left">発売日</th>

--- a/spec/mailers/previews/favored_book_notification_mailer_preview.rb
+++ b/spec/mailers/previews/favored_book_notification_mailer_preview.rb
@@ -2,7 +2,7 @@
 class FavoredBookNotificationMailerPreview < ActionMailer::Preview
 
   def send_favored_book_notification_email
-    FavoredBookNotificationMailer.send_notification_email(User.find(1))
+    FavoredBookNotificationMailer.send_favored_book_notification_email(User.find(1))
   end
 
 end


### PR DESCRIPTION
## 説明
- 発売前通知メールに表紙イメージ(@large_image_url)を追加
- send_favored_book_notification_mailer_previewのデバッグ